### PR TITLE
Allow specifying custom FilePath for recording

### DIFF
--- a/Plugin.AudioRecorder.Droid/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Droid/AudioRecorderService.cs
@@ -1,7 +1,8 @@
-﻿using Android.Content;
+using Android.Content;
 using Android.Media;
 using System.IO;
 using System;
+using System.Threading.Tasks;
 
 namespace Plugin.AudioRecorder
 {
@@ -9,8 +10,6 @@ namespace Plugin.AudioRecorder
 	{
 		partial void Init ()
 		{
-			filePath = Path.Combine (Path.GetTempPath (), RecordingFileName);
-
 			if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.JellyBean)
 			{
 				try
@@ -33,6 +32,11 @@ namespace Plugin.AudioRecorder
 					System.Diagnostics.Debug.WriteLine ("PreferredSampleRate will remain at the default");
 				}
 			}
+		}
+
+		Task<string> GetDefaultFilePath ()
+		{
+			return Task.FromResult(Path.Combine(Path.GetTempPath(), DefaultFileName));
 		}
 	}
 }

--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -9,13 +9,12 @@ namespace Plugin.AudioRecorder
 	/// </summary>
 	public partial class AudioRecorderService
 	{
-		const string RecordingFileName = "ARS_recording.wav";
+		const string DefaultFileName = "ARS_recording.wav";
 
 		WaveRecorder recorder;
 		IAudioStream audioStream;
 
 		bool audioDetected;
-		string filePath;
 		DateTime? silenceTime;
 		DateTime? startTime;
 		TaskCompletionSource<string> recordTask;
@@ -26,6 +25,13 @@ namespace Plugin.AudioRecorder
 		/// </summary>
 		/// <remarks>Accessible once <see cref="StartRecording"/> has been called.</remarks>
 		public AudioStreamDetails AudioStreamDetails { get; private set; }
+
+
+		/// <summary>
+		/// Gets/sets the desired file path. If null it will be set automatically
+		/// to a temporary file.
+		/// </summary>
+		public string FilePath { get; set; }
 
 
 		/// <summary>
@@ -92,7 +98,7 @@ namespace Plugin.AudioRecorder
 		/// </summary>
 		public AudioRecorderService ()
 		{
-			Init ();
+			Init();
 		}
 
 
@@ -103,11 +109,16 @@ namespace Plugin.AudioRecorder
 		/// The task result will be the path to the recorded audio file, or null if no audio was recorded.</returns>
 		public async Task<Task<string>> StartRecording ()
 		{
+			if (FilePath == null)
+			{
+				FilePath = await GetDefaultFilePath ();
+			}
+
 			ResetAudioDetection ();
 
 			InitializeStream (PreferredSampleRate);
 
-			await recorder.StartRecorder (audioStream, filePath);
+			await recorder.StartRecorder (audioStream, FilePath);
 
 			AudioStreamDetails = new AudioStreamDetails
 			{
@@ -266,7 +277,7 @@ namespace Plugin.AudioRecorder
 		/// <returns>The full filepath to the recorded audio file, or null if no audio was detected during the last record.</returns>
 		public string GetAudioFilePath ()
 		{
-			return audioDetected ? filePath : null;
+			return audioDetected ? FilePath : null;
 		}
 	}
 }

--- a/Plugin.AudioRecorder.UWP/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.UWP/AudioRecorderService.cs
@@ -1,16 +1,18 @@
-﻿using System;
+using System;
 using Windows.Storage;
+using System.Threading.Tasks;
 
 namespace Plugin.AudioRecorder
 {
-    public partial class AudioRecorderService
-    {
-        async partial void Init()
-        {
-            StorageFolder temporaryFolder = ApplicationData.Current.TemporaryFolder;
-            StorageFile tempFile = await temporaryFolder.CreateFileAsync(RecordingFileName, CreationCollisionOption.ReplaceExisting);
+	public partial class AudioRecorderService
+	{
+		partial void Init () { }
 
-            filePath = tempFile.Path;
-        }
-    }
+		async Task<string> GetDefaultFilePath ()
+		{
+			StorageFolder temporaryFolder = ApplicationData.Current.TemporaryFolder;
+			StorageFile tempFile = await temporaryFolder.CreateFileAsync(DefaultFileName, CreationCollisionOption.ReplaceExisting);
+			return tempFile.Path;
+		}
+	}
 }

--- a/Plugin.AudioRecorder.iOS/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.iOS/AudioRecorderService.cs
@@ -1,12 +1,15 @@
-﻿using System.IO;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace Plugin.AudioRecorder
 {
-    public partial class AudioRecorderService
-    {
-        partial void Init()
-        {
-            filePath = Path.Combine(Path.GetTempPath(), RecordingFileName);
-        }
-    }
+	public partial class AudioRecorderService
+	{
+		partial void Init () { }
+
+		Task<string> GetDefaultFilePath ()
+		{
+			return Task.FromResult(Path.Combine(Path.GetTempPath(), DefaultFileName));
+		}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ An example of the Task-based API and concurrent writing and reading of the audio
 	
 	Gets/sets a value indicating the signal threshold that determines silence.  If the recorder is being over or under aggressive when detecting silence, you can alter this value to achieve different results.  Defaults to .2. Value should be between 0 and 1.
 
+- FilePath
+
+	```C#
+	string FilePath
+	```
+
+	Gets/sets the desired file path. If null it will be set automatically to a temporary file.
+
 
 # Limitations
 


### PR DESCRIPTION
This branch is based on the branch in #14 (kind of, I couldn't figure out how to only PR the single additional commit on top of #14 so I created a new branch with only the filepath change to make it easier to review) and should fix issue #3.

This change adds a FilePath property that can be set by the consumer of AudioRecorderService. If not set, it will fallback to the original behavior.

This change does alter the overridding behavior for properties such as PreferredSampleRate on Android as it previously would allow the user's value to override what the Android platform was. The new behavior would result in the Android platform value being evaluated after the user's value had been set (rather than before). The issue was that I wanted to avoid the default path behavior as UWP has side effects (creating the file) that I didn't want to have occur if the user had provided a FilePath.