### PR TITLE
Add editorconfig file to try to enforce code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+
+[*.cs]
+indent_style = tab


### PR DESCRIPTION
While working on #15 I found that my Visual Studio settings were at odds with the formatting in the files and I figured others may have the same issue so I'd contribute the editorconfig file I used to get my editor settings to conform.