### PR TITLE
Wave Header Incorrect

### DIFF
--- a/Plugin.AudioRecorder.Shared/AudioFunctions.cs
+++ b/Plugin.AudioRecorder.Shared/AudioFunctions.cs
@@ -45,7 +45,7 @@ namespace Plugin.AudioRecorder
 
 			if (audioLength > -1)
 			{
-				writer.Write (audioLength + 36); // 36 + subchunk 2 size (data size)
+				writer.Write ((Int32)(audioLength - 8)); // Size of the overall file - 8 bytes, in bytes (32-bit integer). 
 			}
 			else
 			{
@@ -71,7 +71,7 @@ namespace Plugin.AudioRecorder
 			writer.Write (Encoding.UTF8.GetBytes ("data"));
 
 			//subchunk 2 (data) size
-			writer.Write (audioLength);
+			writer.Write (audioLength-44);
 		}
 
 		// Adapted from http://stackoverflow.com/questions/5800649/detect-silence-when-recording


### PR DESCRIPTION
First of all many thanks for this great module.

When trying to use it we discovered an issue with .wav-file that was generated.
Android refused to play the file.
After some comparisons we found the header of generated files are incorrect.
While a some music players accept that, others like on Android do not.

The documentation we found shows that file length is calculated like this:
"Size of the overall file - 8 bytes, in bytes (32-bit integer). "
So that means that line 48 of AudioFunctions should be:
`writer.Write (audioLength - 1);`

Then the data length is filelength minus the header.
And line 74:
`writer.Write (audioLength-44);`

Best regards,
Marco