### PR TITLE
Added in-memory audio stream and audio level event

### DIFF
--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -82,6 +82,12 @@ namespace Plugin.AudioRecorder
 		/// <remarks>This event will be raised on a background thread to allow for any further processing needed.  The audio file will be <c>null</c> in the case that no audio was recorded.</remarks>
 		public event EventHandler<string> AudioInputReceived;
 
+		/// <summary>
+		/// Gets/sets a value indicating if the <see cref="AudioRecorderService"/> should write audio data to a file.
+		/// </summary>
+		/// <remarks>Defaults to <c>true</c></remarks>
+		public bool WriteAudioDataToFile { get; set; } = true;
+
 		partial void Init ();
 
 		/// <summary>
@@ -247,7 +253,9 @@ namespace Plugin.AudioRecorder
 
 				if (recorder == null)
 				{
-					recorder = new WaveRecorder ();
+					recorder = new WaveRecorder {
+						WriteAudioDataToFile = WriteAudioDataToFile
+					};
 				}
 			}
 			catch (Exception ex)
@@ -263,6 +271,15 @@ namespace Plugin.AudioRecorder
 		public string GetAudioFilePath ()
 		{
 			return audioDetected ? FilePath : null;
+		}
+
+		/// <summary>
+		/// Gets a new <see cref="Stream"/> to the audio data in readonly mode.
+		/// </summary>
+		/// <returns>A <see cref="Stream"/> object that can be used to read the audio memory from the beginning.</returns>
+		public Stream GetAudioMemoryStream()
+		{
+			return recorder.GetAudioMemoryStream();
 		}
 	}
 }

--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -83,6 +83,12 @@ namespace Plugin.AudioRecorder
 		public event EventHandler<string> AudioInputReceived;
 
 		/// <summary>
+		/// This event is raised when the most recent audio level has been calculated.
+		/// </summary>
+		/// <remarks>This event will be raised on a background thread to allow for any further processing needed.  The audio level will be <c>0.0f</c> in the case that no audio was recorded.</remarks>
+		public event EventHandler<float> AudioLevelUpdated;
+
+		/// <summary>
 		/// Gets/sets a value indicating if the <see cref="AudioRecorderService"/> should write audio data to a file.
 		/// </summary>
 		/// <remarks>Defaults to <c>true</c></remarks>
@@ -151,6 +157,8 @@ namespace Plugin.AudioRecorder
 		void AudioStream_OnBroadcast (object sender, byte [] bytes)
 		{
 			var level = AudioFunctions.CalculateLevel (bytes);
+
+			AudioLevelUpdated?.Invoke(this, level);
 
 			if (level < NearZero && !audioDetected) // discard any initial 0s so we don't jump the gun on timing out
 			{

--- a/Samples/Forms/AudioRecord.Forms/MainPage.xaml.cs
+++ b/Samples/Forms/AudioRecord.Forms/MainPage.xaml.cs
@@ -20,9 +20,14 @@ namespace AudioRecord.Forms
 				TotalAudioTimeout = TimeSpan.FromSeconds (15),
 				AudioSilenceTimeout = TimeSpan.FromSeconds (2)
 			};
+			recorder.AudioLevelUpdated += Recorder_AudioLevelUpdated;
 
 			player = new AudioPlayer ();
 			player.FinishedPlaying += Player_FinishedPlaying;
+		}
+
+		public void Recorder_AudioLevelUpdated (object sender, float level)
+		{
 		}
 
 		async void Record_Clicked (object sender, EventArgs e)


### PR DESCRIPTION
I plan to implement an app using Plugin.AudioRecorder that will use a continuous stream of audio. I won't necessarily need to store the audio in files on disk, so I've added a MemoryStream option to Plugin.AudioRecorder. I have not changed the default behaviour of storing audio to a file, so the changes should not affect any existing users of Plugin.AudioRecorder.

I would also like my app to display a visual representation of the current audio level, so I've added an event that is invoked when the audio level is updated.

I would greatly appreciate if these changes could be added to the next release of Plugin.AudioRecorder. Thank you!