### PR TITLE
Use custom stream to record audio

### DIFF
--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -97,7 +97,7 @@ namespace Plugin.AudioRecorder
 		/// Starts recording audio.
 		/// </summary>
 		/// <param name="recordStream"><c>null</c> (default) Optional stream to write audio data to, if null, a file will be created.</param>
-		/// <param name="writeHeaders"><c>false</c> (default) Set to true, to write WAV headers after recording. Note that stream should be seekable.</param>
+		/// <param name="writeHeaders"><c>false</c> (default) Set to true, to write WAV headers to recordStream after recording. Requires a seekable stream.</param>
 		/// <returns>A <see cref="Task"/> that will complete when recording is finished.  
 		/// The task result will be the path to the recorded audio file, or null if no audio was recorded.</returns>
 		public async Task<Task<string>> StartRecording (Stream recordStream = null, bool writeHeaders = false)

--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -76,6 +76,12 @@ namespace Plugin.AudioRecorder
 		/// </summary>
 		/// <remarks>Defaults to .15.  Value should be between 0 and 1.</remarks>
 		public float SilenceThreshold { get; set; } = .15f;
+		
+		/// <summary>
+		/// Gets/sets a value indicating if headers will be written to the file/stream.
+		/// </summary>
+		/// <remarks>Defaults to <c>true</c></remarks>
+		public bool WriteHeaders { get; set; } = true;
 
 		/// <summary>
 		/// This event is raised when audio recording is complete and delivers a full filepath to the recorded audio file.
@@ -100,7 +106,7 @@ namespace Plugin.AudioRecorder
 		/// <param name="writeHeaders"><c>false</c> (default) Set to true, to write WAV headers to recordStream after recording. Requires a seekable stream.</param>
 		/// <returns>A <see cref="Task"/> that will complete when recording is finished.  
 		/// The task result will be the path to the recorded audio file, or null if no audio was recorded.</returns>
-		public async Task<Task<string>> StartRecording (Stream recordStream = null, bool writeHeaders = false)
+		public async Task<Task<string>> StartRecording (Stream recordStream = null)
 		{
 			if (recordStream == null)
 			{
@@ -110,7 +116,6 @@ namespace Plugin.AudioRecorder
 				}
 				fileStream = new FileStream (FilePath, FileMode.Create, FileAccess.Write, FileShare.Read);
 				recordStream = fileStream;
-				writeHeaders = true;
 			}
 
 			ResetAudioDetection ();
@@ -118,7 +123,7 @@ namespace Plugin.AudioRecorder
 
 			InitializeStream (PreferredSampleRate);
 
-			await recorder.StartRecorder (audioStream, recordStream, writeHeaders);
+			await recorder.StartRecorder (audioStream, recordStream, WriteHeaders);
 
 			AudioStreamDetails = new AudioStreamDetails
 			{

--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -21,6 +21,7 @@ namespace Plugin.AudioRecorder
 		DateTime? silenceTime;
 		DateTime? startTime;
 		TaskCompletionSource<string> recordTask;
+		FileStream fileStream;
 
 		/// <summary>
 		/// Gets the details of the underlying audio stream.
@@ -95,13 +96,20 @@ namespace Plugin.AudioRecorder
 		/// <summary>
 		/// Starts recording audio.
 		/// </summary>
+		/// <param name="recordStream"><c>null</c> (default) optional stream to write audio data to, if null, a file will be created.
 		/// <returns>A <see cref="Task"/> that will complete when recording is finished.  
 		/// The task result will be the path to the recorded audio file, or null if no audio was recorded.</returns>
-		public async Task<Task<string>> StartRecording ()
+		/// <param name="recordStream"></param>
+		public async Task<Task<string>> StartRecording (Stream recordStream = null)
 		{
-			if (FilePath == null)
+			if (recordStream == null)
 			{
-				FilePath = await GetDefaultFilePath ();
+				if (FilePath == null)
+				{
+					FilePath = await GetDefaultFilePath ();
+				}
+				fileStream = new FileStream (FilePath, FileMode.Create, FileAccess.Write, FileShare.Read);
+				recordStream = fileStream; 
 			}
 
 			ResetAudioDetection ();
@@ -109,7 +117,7 @@ namespace Plugin.AudioRecorder
 
 			InitializeStream (PreferredSampleRate);
 
-			await recorder.StartRecorder (audioStream, FilePath);
+			await recorder.StartRecorder (audioStream, recordStream);
 
 			AudioStreamDetails = new AudioStreamDetails
 			{
@@ -132,7 +140,8 @@ namespace Plugin.AudioRecorder
 		/// <returns>A <see cref="Stream"/> object that can be used to read the audio file from the beginning.</returns>
 		public Stream GetAudioFileStream ()
 		{
-			return recorder.GetAudioFileStream ();
+			//return a new stream to the same audio file, in Read mode
+			return new FileStream (FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 		}
 
 		void ResetAudioDetection ()
@@ -216,10 +225,11 @@ namespace Plugin.AudioRecorder
 				Debug.WriteLine ("Error in StopRecording: {0}", ex);
 			}
 
+			fileStream?.Dispose();
 			OnRecordingStopped ();
 
 			var returnedFilePath = GetAudioFilePath ();
-			// complete the recording Task for anthing waiting on this
+			// complete the recording Task for anything waiting on this
 			recordTask.TrySetResult (returnedFilePath);
 
 			if (continueProcessing)

--- a/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
+++ b/Plugin.AudioRecorder.Shared/AudioRecorderService.cs
@@ -96,11 +96,11 @@ namespace Plugin.AudioRecorder
 		/// <summary>
 		/// Starts recording audio.
 		/// </summary>
-		/// <param name="recordStream"><c>null</c> (default) optional stream to write audio data to, if null, a file will be created.
+		/// <param name="recordStream"><c>null</c> (default) Optional stream to write audio data to, if null, a file will be created.</param>
+		/// <param name="writeHeaders"><c>false</c> (default) Set to true, to write WAV headers after recording. Note that stream should be seekable.</param>
 		/// <returns>A <see cref="Task"/> that will complete when recording is finished.  
 		/// The task result will be the path to the recorded audio file, or null if no audio was recorded.</returns>
-		/// <param name="recordStream"></param>
-		public async Task<Task<string>> StartRecording (Stream recordStream = null)
+		public async Task<Task<string>> StartRecording (Stream recordStream = null, bool writeHeaders = false)
 		{
 			if (recordStream == null)
 			{
@@ -109,7 +109,8 @@ namespace Plugin.AudioRecorder
 					FilePath = await GetDefaultFilePath ();
 				}
 				fileStream = new FileStream (FilePath, FileMode.Create, FileAccess.Write, FileShare.Read);
-				recordStream = fileStream; 
+				recordStream = fileStream;
+				writeHeaders = true;
 			}
 
 			ResetAudioDetection ();
@@ -117,7 +118,7 @@ namespace Plugin.AudioRecorder
 
 			InitializeStream (PreferredSampleRate);
 
-			await recorder.StartRecorder (audioStream, recordStream);
+			await recorder.StartRecorder (audioStream, recordStream, writeHeaders);
 
 			AudioStreamDetails = new AudioStreamDetails
 			{

--- a/Plugin.AudioRecorder.Shared/WaveRecorder.cs
+++ b/Plugin.AudioRecorder.Shared/WaveRecorder.cs
@@ -8,9 +8,6 @@ namespace Plugin.AudioRecorder
 {
 	internal class WaveRecorder : IDisposable
 	{
-		string audioFilePath;
-		FileStream fileStream;
-		StreamWriter streamWriter;
 		BinaryWriter writer;
 		int byteCount;
 		IAudioStream audioStream;
@@ -19,10 +16,15 @@ namespace Plugin.AudioRecorder
 		/// Starts recording WAVE format audio from the audio stream.
 		/// </summary>
 		/// <param name="stream">A <see cref="IAudioStream"/> that provides the audio data.</param>
-		/// <param name="filePath">The full path of the file to record audio to.</param>
-		public async Task StartRecorder (IAudioStream stream, string filePath)
+		/// <param name="recordStream">The stream the audio will be written to.</param>
+		public async Task StartRecorder (IAudioStream stream, Stream recordStream)
 		{
 			if (stream == null)
+			{
+				throw new ArgumentNullException (nameof (stream));
+			}
+
+			if (recordStream == null)
 			{
 				throw new ArgumentNullException (nameof (stream));
 			}
@@ -34,13 +36,9 @@ namespace Plugin.AudioRecorder
 				{
 					await audioStream.Stop ();
 				}
-
-				audioFilePath = filePath;
+				
 				audioStream = stream;
-
-				fileStream = new FileStream (filePath, FileMode.Create, FileAccess.Write, FileShare.Read);
-				streamWriter = new StreamWriter (fileStream);
-				writer = new BinaryWriter (streamWriter.BaseStream, Encoding.UTF8);
+				writer = new BinaryWriter (recordStream, Encoding.UTF8, true);
 
 				byteCount = 0;
 				audioStream.OnBroadcast += OnStreamBroadcast;
@@ -59,17 +57,7 @@ namespace Plugin.AudioRecorder
 				throw;
 			}
 		}
-
-		/// <summary>
-		/// Gets a new <see cref="Stream"/> to the audio file in readonly mode.
-		/// </summary>
-		/// <returns>A <see cref="Stream"/> object that can be used to read the audio file from the beginning.</returns>
-		public Stream GetAudioFileStream ()
-		{
-			//return a new stream to the same audio file, in Read mode
-			return new FileStream (audioFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-		}
-
+		
 		void StreamActiveChanged (object sender, bool active)
 		{
 			if (!active)
@@ -82,7 +70,7 @@ namespace Plugin.AudioRecorder
 		{
 			try
 			{
-				if (writer != null && streamWriter != null)
+				if (writer != null)
 				{
 					writer.Write (bytes);
 					byteCount += bytes.Length;
@@ -111,7 +99,7 @@ namespace Plugin.AudioRecorder
 
 				if (writer != null)
 				{
-					if (streamWriter.BaseStream.CanWrite)
+					if (writer.BaseStream.CanWrite && writer.BaseStream.CanSeek)
 					{
 						//now that audio is finished recording, write a WAV/RIFF header at the beginning of the file
 						writer.Seek (0, SeekOrigin.Begin);
@@ -120,8 +108,6 @@ namespace Plugin.AudioRecorder
 
 					writer.Dispose (); //this should properly close/dispose the underlying stream as well
 					writer = null;
-					fileStream = null;
-					streamWriter = null;
 				}
 
 				audioStream = null;

--- a/Plugin.AudioRecorder.Shared/WaveRecorder.cs
+++ b/Plugin.AudioRecorder.Shared/WaveRecorder.cs
@@ -11,13 +11,15 @@ namespace Plugin.AudioRecorder
 		BinaryWriter writer;
 		int byteCount;
 		IAudioStream audioStream;
+		bool writeHeadersToStream;
 
 		/// <summary>
 		/// Starts recording WAVE format audio from the audio stream.
 		/// </summary>
 		/// <param name="stream">A <see cref="IAudioStream"/> that provides the audio data.</param>
 		/// <param name="recordStream">The stream the audio will be written to.</param>
-		public async Task StartRecorder (IAudioStream stream, Stream recordStream)
+		/// <param name="writeHeaders"><c>false</c> (default) Write WAV headers to stream at the end of recording.</param>
+		public async Task StartRecorder (IAudioStream stream, Stream recordStream, bool writeHeaders = false)
 		{
 			if (stream == null)
 			{
@@ -26,8 +28,10 @@ namespace Plugin.AudioRecorder
 
 			if (recordStream == null)
 			{
-				throw new ArgumentNullException (nameof (stream));
+				throw new ArgumentNullException (nameof (recordStream));
 			}
+
+			writeHeadersToStream = writeHeaders;
 
 			try
 			{
@@ -99,7 +103,7 @@ namespace Plugin.AudioRecorder
 
 				if (writer != null)
 				{
-					if (writer.BaseStream.CanWrite && writer.BaseStream.CanSeek)
+					if (writeHeadersToStream && writer.BaseStream.CanWrite && writer.BaseStream.CanSeek)
 					{
 						//now that audio is finished recording, write a WAV/RIFF header at the beginning of the file
 						writer.Seek (0, SeekOrigin.Begin);


### PR DESCRIPTION
Hello,
This code change allows you to use your own stream when recording audio. The StartRecording function now accepts a stream object:
```
public async Task<Task<string>> StartRecording (Stream recordStream = null, bool writeHeaders = false)
```
If `recordStream` is `null` the old behavior is used where a file is written on the device. The writeHeaders flag can be used to write the WAV headers to the beginning of the stream.

Example usage:
```
var memoryStream = new MemoryStream();
var audioRecordTask = await recorder.StartRecording (memoryStream, true);
```
I added this change for my scenario where I don't want data to be stored on the device or use an internal memoryStream like #48.
This change will also allow scenarios mentioned in #12 and #13 by reusing the stream. It also supports the scenario of #48, using a memory stream instead of filestream.  
