### PR TITLE
Fix wav saving

### DIFF
--- a/Samples/Forms/AudioRecord.Forms.Android/AudioRecord.Forms.Android.csproj
+++ b/Samples/Forms/AudioRecord.Forms.Android/AudioRecord.Forms.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Samples/Native/AudioRecord.Android/AudioRecord.Android.csproj
+++ b/Samples/Native/AudioRecord.Android/AudioRecord.Android.csproj
@@ -17,7 +17,6 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>


### PR DESCRIPTION
This PR fixes wav saving as the original code overwrites the initial bytes of audio. Also fixes #53 as some platform enforces correctness of wav files when playing them